### PR TITLE
Verlegt ID, Schlüssel geändert, war falsch

### DIFF
--- a/fim/schema/vwm/1.0.0.json
+++ b/fim/schema/vwm/1.0.0.json
@@ -373,11 +373,11 @@
                                 1,
                                 2,
                                 3,
+                                4,
                                 5,
                                 6,
                                 7,
-                                8,
-                                9
+                                8
                             ],
                             "enumLabels": [
                                 "nicht verschoben",


### PR DESCRIPTION
Ich hab die Verlegt ID geändert, da war eine falsche Zahl drin. Die 4 hat gefehlt und dadurch sind die IDs verrutscht 